### PR TITLE
Update peer-dependencies

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -17,7 +17,7 @@
 	},
 	"peerDependencies": {
 		"react": "^16.11.0",
-		"react-native": "^0.62.0"
+		"react-native": ">=0.62.0<0.64.0"
 	},
 	"dependencies": {
 		"@types/react": "*",


### PR DESCRIPTION
This removes the peer-dependency warning when installing react-native-dynamic along with react-native 0.63.3