### PR TITLE
feat: add console.trace to no dynamic warning

### DIFF
--- a/library/src/dynamic-style-sheet.ts
+++ b/library/src/dynamic-style-sheet.ts
@@ -48,6 +48,7 @@ function parseStylesFor<T extends DynamicStyles<T>>(styles: T, mode: Mode): Norm
 		console.warn(
 			'A DynamicStyleSheet was used without any DynamicValues. Consider replacing with a regular StyleSheet.',
 		)
+		console.trace()
 	}
 
 	return (newStyles as unknown) as NormalizeStyles<T>


### PR DESCRIPTION
In order to help the developer experience, add a console.trace to the warning message.